### PR TITLE
Fix links to previous episodes

### DIFF
--- a/source/_posts/2022-11-08-tower-3.md
+++ b/source/_posts/2022-11-08-tower-3.md
@@ -7,9 +7,9 @@ tags:
 - tower
 ---
 
-In the [previous episode](/2022/10/23/2022-10-23-tower-2) we have seen how to call a Tower service. In particular we have discussed the contract between `poll_ready` and `call`: callers must first invoke `poll_ready` until it returns `Poll::Ready` before they invoke `call`, else `call` might panic.
+In the [previous episode](/2022/10/22/2022-10-23-tower-2) we have seen how to call a Tower service. In particular we have discussed the contract between `poll_ready` and `call`: callers must first invoke `poll_ready` until it returns `Poll::Ready` before they invoke `call`, else `call` might panic.
 
-Of course some services, e.g. the `EchoService` described in the [first episode](/2022/10/21/2022-10-21-tower-1), are always ready and therefore invokig `call` without `poll_ready` works fine.
+Of course some services, e.g. the `EchoService` described in the [first episode](/2022/10/20/2022-10-21-tower-1), are always ready and therefore invokig `call` without `poll_ready` works fine.
 
 But generally the internal state or external dependencies, e.g. database connections, can infuence the readiness of a service. Also, composing domain services with middleware, e.g. with a rate limit or a circuit breaker, naturally effect the readiness.
 


### PR DESCRIPTION
I couldn't find an 'Issues'-tab, but all the "tower" episodes linking to other episodes have an off-by-one error in the url. Probably the proper fix is somewhere else, because the paths don't match the dates.